### PR TITLE
Docs: Setup Pipeline

### DIFF
--- a/.github/workflows/pull_request-opened.yml
+++ b/.github/workflows/pull_request-opened.yml
@@ -25,5 +25,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `${pull_request.body}\n\n---\n[Documentation](https://${context.repo.owner}.github.io/${context.repo.repo}/${head.ref})`
+              body: `${pull_request.body}\n\n---\n[Documentation of `${head.ref}`](https://${context.repo.owner}.github.io/${context.repo.repo}/${head.ref})`
             });

--- a/.github/workflows/pull_request-opened.yml
+++ b/.github/workflows/pull_request-opened.yml
@@ -1,0 +1,29 @@
+name: Pull Request Opened
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  link_docs:
+    name: Link Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Action Script
+        uses: actions/github-script@0.4.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { pull_request } = context.payload;
+            const { base, head } = pull_request;
+            if (base.repo.id !== head.repo.id) {
+              console.info('Skipping pull request from fork');
+              return;
+            }
+
+            await github.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${pull_request.body}\n\n---\n[Documentation](https://${context.repo.owner}.github.io/${context.repo.repo}/${head.ref})`
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,5 @@ var/*
 /docker/sawtooth-pbft/keys
 
 # Generated documentation
-docs/build
-docs/source/_autosummary
+/docs/build
+/docs/source/api

--- a/.travis-scripts/docs.sh
+++ b/.travis-scripts/docs.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -e
+
+run() {
+	printf "$ $ANSI_YELLOW%s$ANSI_CLEAR\n" "$(echo $@)" >&2
+	"$@"
+}
+
+remote_url="$(git remote get-url origin)"
+pages_dir="$TRAVIS_BUILD_DIR-gh-pages"
+
+echo 'Write GITHUB_ACCESS_TOKEN to ~/.netrc'
+cat > ~/.netrc << EOF
+machine github.com
+  login $GITHUB_ACCESS_TOKEN
+EOF
+
+run git clone --depth=1 --no-single-branch --branch=gh-pages "$remote_url" "$pages_dir"
+run cd "$pages_dir"
+
+run find . -name .is_ref | while read line; do
+	ref="$(dirname "$line")"
+	ref="${ref:2}"
+	if ! git rev-parse --verify -q "refs/remotes/origin/$ref" > /dev/null; then
+		run rm -rf "$ref"
+	fi
+done
+
+run git status
+
+run cd "$TRAVIS_BUILD_DIR"
+run docker run --rm -i -v "$TRAVIS_BUILD_DIR:/app" -w /app mgjm/sn3t:base << EOF
+apt-get update
+apt-get install -y make graphviz
+
+pip3 install -r docs/requirements.txt
+
+ln -s /app/testbed "\$PYTHONPATH/testbed"
+
+export VERSIONS_JS_URL=https://osmhpi.github.io/cohydra/versions.js
+
+export SUMO_HOME=
+exec make docs BUILD_TAG="$TRAVIS_BRANCH"
+EOF
+
+run rm -rf "$pages_dir/${TRAVIS_BRANCH}"
+run mkdir -pv "$pages_dir/${TRAVIS_BRANCH}"
+run cp -Trv docs/build/dirhtml "$pages_dir/${TRAVIS_BRANCH}"
+run touch "$pages_dir/${TRAVIS_BRANCH}/.is_ref"
+
+run cd "$pages_dir"
+run .travis-scripts/build_versions.py
+
+if [ -z "$(git status --porcelain)" ]; then
+	echo "Nothing to commit"
+else
+	run git add .
+	run git commit -m "Build docs for ${TRAVIS_COMMIT::7} on branch ${TRAVIS_BRANCH}"
+	run git push
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
-language: generic
+language: python
 
-os: linux
-
-services:
-- docker
+if: branch != gh-pages
 
 git:
   submodules: false
 
-script:
-- docker build -t testbed .
-- docker-compose build
-- docker-compose up -d
-- docker run --rm --net host --pid host --userns host --privileged -v /var/run/docker.sock:/var/run/docker.sock:ro testbed examples/basic_example.py
-- docker-compose down
+python: 3.8
+
+jobs:
+  include:
+    - stage: docs
+      script: .travis-scripts/docs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ python: 3.8
 jobs:
   include:
     - stage: docs
+      if: type != pull_request
       script: .travis-scripts/docs.sh

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,4 @@ save: git-is-clean
 		mgjm/sn3t:dev
 
 docs:
-	$(RM) -r docs/source/_autosummary
-	cd docs && \
-		$(MAKE) html && \
-		$(MAKE) clean && \
-		$(MAKE) html && \
-		$(MAKE) html
+	$(MAKE) -C docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,8 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
-export BUILD_TAG = $(shell git rev-parse --abbrev-ref HEAD)
+BUILD_TAG ?= $(shell git rev-parse --abbrev-ref HEAD)
+export BUILD_TAG := ${BUILD_TAG}
 
 .PHONY: all keep-autosummary clean clean-autosummary Makefile
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,3 @@
-# Minimal makefile for Sphinx documentation
-#
-
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
@@ -8,13 +5,25 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
-# Put it first so that "make" without argument is like "make help".
-help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+export BUILD_TAG = $(shell git rev-parse --abbrev-ref HEAD)
 
-.PHONY: help Makefile
+.PHONY: all keep-autosummary clean clean-autosummary Makefile
 
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+all: keep-autosummary
+	$(MAKE) clean-autosummary
+
+keep-autosummary: clean
+	$(MAKE) sphinx-dirhtml
+	$(MAKE) sphinx-clean
+	$(MAKE) sphinx-dirhtml
+	$(MAKE) sphinx-dirhtml
+
+clean: sphinx-clean clean-autosummary
+
+clean-autosummary:
+	$(RM) -r api
+
+help: sphinx-help
+
+sphinx-%: Makefile
+	$(SPHINXBUILD) -M $(@:sphinx-%=%) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx~=2.3
+sphinx_rtd_theme~=0.4.3
+sphinx_autopackagesummary~=1.2

--- a/docs/source/_templates/autosummary/package.rst
+++ b/docs/source/_templates/autosummary/package.rst
@@ -1,53 +1,50 @@
 {{ fullname | escape | underline }}
 
-
 .. automodule:: {{ fullname }}
     :members:
+    :undoc-members:
     :inherited-members:
 
-    {% block functions %}
+    .. autopackagesummary:: {{ fullname }}
+        :toctree: .
+        :template: autosummary/package.rst
+
     {% if functions %}
     .. rubric:: Functions
 
     .. autosummary::
+        :nosignatures:
     {% for item in functions %}
         {{ item }}
     {%- endfor %}
     {% endif %}
-    {% endblock %}
 
-    {% block classes %}
     {% if classes %}
     .. rubric:: Classes
 
     .. autosummary::
+        :nosignatures:
     {% for item in classes %}
         {{ item }}
     {%- endfor %}
     {% endif %}
-    {% endblock %}
 
-    {% block exceptions %}
     {% if exceptions %}
     .. rubric:: Exceptions
 
     .. autosummary::
+        :nosignatures:
     {% for item in exceptions %}
         {{ item }}
     {%- endfor %}
     {% endif %}
-    {% endblock %}
+    
+    |
 
-{% block inheritance %}
 {% if classes %}
+.. rubric:: Inheritance Diagramm
 
-Inheritance Diagramm
-********************
 .. inheritance-diagram:: {{ fullname }}
 
+|
 {% endif %}
-{% endblock %}
-
-.. autopackagesummary:: {{ fullname }}
-    :toctree: .
-    :template: autosummary/package.rst

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,15 @@
+=============
+API Reference
+=============
+
+testbed
+=======
+
+.. automodule:: testbed
+    :members:
+    :undoc-members:
+    :inherited-members:
+
+    .. autopackagesummary:: testbed
+        :toctree: api
+        :template: autosummary/package.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,6 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -97,4 +96,5 @@ extlinks = {
 }
 
 # Inheritance diagram design
-inheritance_graph_attrs = dict(rankdir="LR", fontsize=18)
+inheritance_graph_attrs = dict(rankdir='TB', fontsize=18)
+inheritance_edge_attrs = dict(dir='back', arrowtail='empty', arrowsize=1.5)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,16 +14,26 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import os
+from datetime import datetime
+
 import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
 project = 'testbed'
-copyright = '2020, Arne Boockmeyer, Martin Michaelis, Felix Gohla'
 author = 'Arne Boockmeyer, Martin Michaelis, Felix Gohla'
+copyright = f'{datetime.utcnow().year}, {author}'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.0'
+version = '0.2.0'
+
+if 'BUILD_TAG' in os.environ:
+    release = os.environ['BUILD_TAG']
+    if release != 'master':
+        version = f'{version} - {release}'
+
+release = version
 
 # -- General configuration ---------------------------------------------------
 
@@ -58,7 +68,10 @@ exclude_patterns = []
 #
 html_theme = 'sphinx_rtd_theme'
 
-html_show_sourcelink = True
+html_copy_source = False
+
+if 'VERSIONS_JS_URL' in os.environ:
+    html_js_files = [os.environ['VERSIONS_JS_URL']]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -80,7 +93,7 @@ html_show_sphinx = False
 
 # Link replacement
 extlinks = {
-    'src': ('https://gitlab.hpi.de/robert.schmid/testbed-temp/tree/master/%s', 'src ')
+    'src': ('https://github.com/osmhpi/cohydra/tree/master/%s', 'src ')
 }
 
 # Inheritance diagram design

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ Contents:
 
     installation
     getting-started
-    modules
+    api
 
 Indices and tables
 ==================

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,8 +1,0 @@
-*****************************
-API Reference :mod:`testbed`
-*****************************
-
-.. currentmodule:: testbed
-.. autopackagesummary:: testbed
-    :toctree: _autosummary
-    :template: autosummary/package.rst


### PR DESCRIPTION
This restructures the documentation and adds a configuration for Travis CI to build the documentation and deploy the documentation of all active branches to GitHub Pages.

With this PR Travis no longer fails (#1), but only because the test is removed from the Travis CI configuration. So #1 should stay open as a reminder to setup some automated tests.

---
[Documentation of `docs/pipeline`](https://osmhpi.github.io/cohydra/docs/pipeline)