### PR TITLE
Docker container names with _ and .

### DIFF
--- a/cohydra/node/base.py
+++ b/cohydra/node/base.py
@@ -17,6 +17,13 @@ class Node:
         A unique name for this node.
     """
     def __init__(self, name):
+        # Check the name.
+        # The names are restricted to this set of characters because
+        # the name is used for generating the log file names.
+        for char in name:
+            if not (char.isalnum() or char in ['-', '_', '.']):
+                raise ValueError('Please only supply alphanumeric names and "-", "_" and ".".')
+
         #: The cannels the node is connected to.
         self.channels = list()
         #: The name of the node.

--- a/cohydra/node/base.py
+++ b/cohydra/node/base.py
@@ -21,7 +21,7 @@ class Node:
         # The names are restricted to this set of characters because
         # the name is used for generating the log file names.
         for char in name:
-            if not (char.isalnum() or char in ['-', '_', '.']):
+            if not (char.isalnum() or char in '-_.'):
                 raise ValueError('Please only supply alphanumeric names and "-", "_" and ".".')
 
         #: The cannels the node is connected to.

--- a/cohydra/node/base.py
+++ b/cohydra/node/base.py
@@ -14,12 +14,9 @@ class Node:
     Parameters
     ----------
     name : str
-        A unique name for this node consisting only of alphanumeric characters.
+        A unique name for this node.
     """
     def __init__(self, name):
-        for char in name:
-            if not (char.isalnum() or char == '-'):
-                raise ValueError('Please only supply alphanumeric names and "-"')
         #: The cannels the node is connected to.
         self.channels = list()
         #: The name of the node.

--- a/cohydra/node/docker.py
+++ b/cohydra/node/docker.py
@@ -88,9 +88,6 @@ class DockerNode(Node):
 
     def __init__(self, name, docker_image=None, docker_build_dir=None, dockerfile='Dockerfile',
                  cpus=0.0, memory=None, command=None, volumes=None, exposed_ports=None, environment_variables=None):
-        for char in name:
-            if not (char.isalnum() or char in ['-', '_', '.']):
-                raise ValueError('Please only supply alphanumeric names and "-", "_" and ".".')
         super().__init__(name)
         #: The docker image to use.
         self.docker_image = docker_image

--- a/cohydra/node/docker.py
+++ b/cohydra/node/docker.py
@@ -60,6 +60,7 @@ class DockerNode(Node):
     ----------
     name : str
         The name of the node (and container).
+        It must consist only of *alphanumeric characters* and :code:`-`, :code:`_` and :code:`.`.
     docker_image : str
         The name of the docker image to use. If not specified,
         `docker_file` and `docker_build_dir` must be set.
@@ -87,7 +88,9 @@ class DockerNode(Node):
 
     def __init__(self, name, docker_image=None, docker_build_dir=None, dockerfile='Dockerfile',
                  cpus=0.0, memory=None, command=None, volumes=None, exposed_ports=None, environment_variables=None):
-
+        for char in name:
+            if not (char.isalnum() or char in ['-', '_', '.']):
+                raise ValueError('Please only supply alphanumeric names and "-", "_" and ".".')
         super().__init__(name)
         #: The docker image to use.
         self.docker_image = docker_image


### PR DESCRIPTION
This should fix #25.

We have to modify #6 in order to check for only - as LXC does not support _ and . in container names!

---
[Documentation of `enhancement/docker-container-names-chracters`](https://osmhpi.github.io/cohydra/enhancement/docker-container-names-chracters)