### PR TITLE
Remove Python exception on Ctrl C during simulation

### DIFF
--- a/cohydra/simulation.py
+++ b/cohydra/simulation.py
@@ -37,7 +37,7 @@ class Simulation:
     .. code-block:: python
 
         with scenario as simulation:
-            simulation.simulate(simluation_time=60)
+            simulation.simulate(simulation_time=60)
 
     Parameters
     ----------
@@ -144,12 +144,30 @@ class Simulation:
         for workflow in self.workflows:
             workflow.stop()
 
-    def simulate(self, simluation_time=None):
+    def simulate(self, simulation_time=None):
         """Simulate the network.
+
+        Aborting the simulation with :kbd:`ctrl` + :kbd:`C` will be catched.
 
         Parameters
         ----------
-        simluation_time : float
+        simulation_time : float
+            The simulation timeout in seconds.
+            If set to :code:`None` the simulation will continue until being manually aborted.
+        """
+        try:
+            self.__simulate(simulation_time)
+        except KeyboardInterrupt:
+            pass
+
+    def __simulate(self, simulation_time=None):
+        """Simulate the network.
+
+        *Warning:* This method does not catch Keyboard errors.
+
+        Parameters
+        ----------
+        simulation_time : float
             The simulation timeout in seconds.
             If set to :code:`None` the simulation will continue until being manually aborted.
         """
@@ -168,14 +186,14 @@ class Simulation:
             mobility_input.start()
             defer('stop mobility input', mobility_input.destroy)
 
-        if simluation_time is not None:
-            logger.info('Simulating for %.4fs', simluation_time)
+        if simulation_time is not None:
+            logger.info('Simulating for %.4fs', simulation_time)
         else:
             logger.info('Simulating until process gets stopped')
 
         def run_simulation():
-            if simluation_time is not None:
-                core.Simulator.Stop(core.Seconds(simluation_time))
+            if simulation_time is not None:
+                core.Simulator.Stop(core.Seconds(simulation_time))
             core.Simulator.Run()
             core.Simulator.Destroy()
 

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -14,8 +14,8 @@ def main():
     scenario.add_network(net)
 
     with scenario as sim:
-        # To simulate forever, just do not specifiy the simluation_time parameter.
-        sim.simulate(simluation_time=60)
+        # To simulate forever, just do not specifiy the simulation_time parameter.
+        sim.simulate(simulation_time=60)
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/examples/bridge_example.py
+++ b/examples/bridge_example.py
@@ -15,7 +15,8 @@ def main():
 
     scenario.add_network(net)
     with scenario as sim:
-        sim.simulate(simluation_time=60)
+        # To simulate forever, just do not specifiy the simulation_time parameter.
+        sim.simulate(simulation_time=60)
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/examples/networking_demo.py
+++ b/examples/networking_demo.py
@@ -15,6 +15,7 @@ def main():
     scenario.add_network(net)
 
     with scenario as sim:
+        # To simulate forever, just do not specifiy the simulation_time parameter.
         sim.simulate()
 
 if __name__ == "__main__":

--- a/examples/sawtooth.py
+++ b/examples/sawtooth.py
@@ -26,7 +26,7 @@ def main():
 
     scenario.add_network(net)
     with scenario as sim:
-        # To simulate forever, just do not specifiy the time parameter.
+        # To simulate forever, just do not specifiy the simulation_time parameter.
         sim.simulate()
 
 if __name__ == "__main__":

--- a/examples/sawtooth_pbft.py
+++ b/examples/sawtooth_pbft.py
@@ -46,8 +46,8 @@ def main():
 
     scenario.add_network(net)
     with scenario as sim:
-        # To simulate forever, just do not specifiy the time parameter.
-        sim.simulate(simluation_time=600)
+        # To simulate forever, just do not specifiy the simulation_time parameter.
+        sim.simulate(simulation_time=600)
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/examples/ssh_example.py
+++ b/examples/ssh_example.py
@@ -15,7 +15,8 @@ def main():
 
     scenario.add_network(net)
     with scenario as sim:
-        sim.simulate(simluation_time=60)
+        # To simulate forever, just do not specifiy the simulation_time parameter.
+        sim.simulate(simulation_time=60)
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/examples/sumo_example.py
+++ b/examples/sumo_example.py
@@ -21,8 +21,8 @@ def main():
     scenario.add_mobility_input(sumo)
 
     with scenario as sim:
-        # To simulate forever, just do not specifiy the simluation_time parameter.
-        sim.simulate(simluation_time=30)
+        # To simulate forever, just do not specifiy the simulation_time parameter.
+        sim.simulate(simulation_time=30)
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/examples/volumes_and_ports_example.py
+++ b/examples/volumes_and_ports_example.py
@@ -35,8 +35,8 @@ def main():
 
     scenario.add_network(net)
     with scenario as sim:
-        # To simulate forever, just do not specifiy the time parameter.
-        sim.simulate(simluation_time=60)
+        # To simulate forever, just do not specifiy the simulation_time parameter.
+        sim.simulate(simulation_time=60)
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/examples/webserver_example.py
+++ b/examples/webserver_example.py
@@ -19,8 +19,8 @@ def main():
 
     scenario.add_network(net)
     with scenario as sim:
-        # To simulate forever, just do not specifiy the time parameter.
-        sim.simulate(simluation_time=60)
+        # To simulate forever, just do not specifiy the simulation_time parameter.
+        sim.simulate(simulation_time=60)
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/examples/wifi_example.py
+++ b/examples/wifi_example.py
@@ -29,8 +29,8 @@ def main():
             workflow.sleep(2)
 
     with scenario as sim:
-        # To simulate forever, just do not specifiy the simluation_time parameter.
-        sim.simulate(simluation_time=180)
+        # To simulate forever, just do not specifiy the simulation_time parameter.
+        sim.simulate(simulation_time=180)
 
 if __name__ == "__main__":
     parser = ArgumentParser()


### PR DESCRIPTION
This PR removes the annoying Python exception when pressing <kbd>Ctrl</kbd>+<kbd>C</kbd>.
The behaviour applies to all phases of the simulation.

Closes #9.

---
[Documentation of `bugfix/keyboard-interrupt`](https://osmhpi.github.io/cohydra/bugfix/keyboard-interrupt)