### PR TITLE
Optionally pull Docker images

### DIFF
--- a/cohydra/node/docker.py
+++ b/cohydra/node/docker.py
@@ -169,7 +169,7 @@ class DockerNode(Node):
                 repo, *tag = self.docker_image.split(':')
                 tag = tag[0] if len(tag) else 'latest'
                 logger.info('Pulling docker image: %s, tag %s', repo, tag)
-                self.docker_image = client.images.pull(self.docker_image, tag=tag)
+                self.docker_image = client.images.pull(repo, tag=tag)
 
         self.docker_image.tag(self.docker_image_tag)
 


### PR DESCRIPTION
This alters the default behavior of `DockerNode`, which was to always attempt pulling a Docker image when `docker_image` is specified. Thereby we can work around the issue of #28.

Now, users must provide `pull=True` explicitly to enable this behavior. 

If the requested image doesn't exist locally, a pull will still be performed as before.

This also fixes a bug in pulling Docker images, which always downloaded all available tags of a repository. Now, it parses user-provided tags from the `docker_image` parameter, or defaults to 'latest' if none is provided.

---
[Documentation of `docker-pull-optional`](https://osmhpi.github.io/cohydra/docker-pull-optional)