### PR TITLE
Add more documentation to run cohydra without docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ pyton3 basic_example.py
 ```
 
 Cohydra so far has only been tested with **Debian 10 Buster** and **Ubuntu 18.04 Bionic Beaver**.
+
+## Contribution
+
+We are always happy when somebody contributes to cohydra.
+Therefore please create a fork and create a pull request to our repository.
+Make sure, that [`pylint`](https://www.pylint.org/) does not show any additional errors or warnings.
+Also make sure that your code and your pull request is well documented.
+The documentation should also contain how to test your feature, if it is more complex.
+Afterwards we are going to test your new feature and review the code.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
  - Felix Gohla
  - Martin Michaelis
  - Benedikt Schenkel
+ - Robert Schmid
 
 ## Installation
 
@@ -31,8 +32,21 @@ The [`osmhpi/cohydra:base`](./docker/cohydra-base/Dockerfile) image installs all
 
 ### Installation Without Docker
 
-In the case you do not want to use the prebuilt docker, a normal ns-3 installation with *NetAnim* Python bindings will work, too.
-The Python libraries / directory provided by ns-3 has to be in your `PYTHONPATH`, though.
-Cohydra so far has only been tested with **Debian 10 Buster** and **Ubuntu 18.04 Bionic Beaver**.
+Recommended python version: Python 3.7
 
-There is no installation via `pip`.
+In the case you do not want to use the prebuilt docker, a normal ns-3 installation with *NetAnim* Python bindings will work, too.
+To easily install these have a look at our [python wheels repository](https://github.com/osmhpi/python-wheels).
+
+You also need the following packages:
+```shell script
+sudo pip3 install pyroute2 nsenter docker paramiko
+sudo pip3 install git+https://github.com/active-expressions/active-expressions-static-python
+```
+
+The Python libraries / directory provided by ns-3 and all other packages has to be in your `PYTHONPATH`, though.
+To run an example testcase, go to the example folder and run:
+```shell script
+pyton3 basic_example.py
+```
+
+Cohydra so far has only been tested with **Debian 10 Buster** and **Ubuntu 18.04 Bionic Beaver**.


### PR DESCRIPTION
Fix #37 

---
[Documentation of `readme-documentation`](https://osmhpi.github.io/cohydra/readme-documentation)