### PR TITLE
Update ns-3 (3.33)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,4 +23,4 @@ RUN pip3 install --no-cache-dir \
 WORKDIR /root/cohydra
 ENV PATH=${PATH}:/root/cohydra/tools \
 	PYLXD_WARNINGS=
-RUN ln -s /root/cohydra/cohydra $PYTHONPATH/cohydra
+RUN ln -s /root/cohydra/cohydra /usr/local/lib/python3.7/site-packages/cohydra

--- a/.travis-scripts/docker_basic_example.sh
+++ b/.travis-scripts/docker_basic_example.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+docker build -t osmhpi/cohydra-base -f docker/cohydra-base/Dockerfile .
 docker build -t osmhpi/cohydra -f docker/Dockerfile .
 
 cd examples

--- a/.travis-scripts/docker_basic_example.sh
+++ b/.travis-scripts/docker_basic_example.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-make cohydra-base cohydra cohydra-dev latest
+make cohydra-base cohydra latest
 
 cd examples
 

--- a/.travis-scripts/docker_basic_example.sh
+++ b/.travis-scripts/docker_basic_example.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 
-docker build -t osmhpi/cohydra-base -f docker/cohydra-base/Dockerfile .
-docker build -t osmhpi/cohydra -f docker/Dockerfile .
+make cohydra-base cohydra cohydra-dev latest
 
 cd examples
 

--- a/.travis-scripts/docs.sh
+++ b/.travis-scripts/docs.sh
@@ -28,13 +28,14 @@ done
 run git status
 
 run cd "$TRAVIS_BUILD_DIR"
+run make cohydra-base latest
 run docker run --rm -i -v "$TRAVIS_BUILD_DIR:/app" -w /app osmhpi/cohydra:base << EOF
 apt-get update
 apt-get install -y make graphviz
 
 pip3 install -r docs/requirements.txt
 
-ln -s /app/cohydra "/usr/local/lib/python3.7/dist-packages/cohydra"
+ln -s /app/cohydra "/usr/local/lib/python3.7/site-packages/cohydra"
 
 export VERSIONS_JS_URL=https://osmhpi.github.io/cohydra/versions.js
 

--- a/.travis-scripts/docs.sh
+++ b/.travis-scripts/docs.sh
@@ -29,7 +29,7 @@ run git status
 
 run cd "$TRAVIS_BUILD_DIR"
 run make cohydra-base latest
-run docker run --rm -i -v "$TRAVIS_BUILD_DIR:/app" -w /app osmhpi/cohydra:base << EOF
+run docker run --rm -i -v "$TRAVIS_BUILD_DIR:/app" -w /app osmhpi/cohydra:base bash << EOF
 apt-get update
 apt-get install -y make graphviz
 

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ else
 endif
 
 
-latest: git-is-clean all
-	docker tag osmhpi/cohydra:base-${COHYDRA_TAG} osmhpi/cohydra:base
-	docker tag osmhpi/cohydra:${COHYDRA_TAG} osmhpi/cohydra:latest
-	docker tag osmhpi/cohydra:dev-${COHYDRA_TAG} osmhpi/cohydra:dev
+latest:
+	docker tag osmhpi/cohydra:base-${COHYDRA_TAG} osmhpi/cohydra:base || true
+	docker tag osmhpi/cohydra:${COHYDRA_TAG} osmhpi/cohydra:latest 	  || true
+	docker tag osmhpi/cohydra:dev-${COHYDRA_TAG} osmhpi/cohydra:dev   || true
 
 cohydra-base:
 	${docker_build} -t osmhpi/cohydra:base-${COHYDRA_TAG} docker/cohydra-base

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export NS3_TAG ?= 3.30
+export NS3_TAG ?= 3.33
 export SUMO_TAG ?= 1.4.0
 COHYDRA_TAG ?= $(shell if [ -z "`git status --porcelain`" ]; then git rev-parse --short HEAD; else echo dirty; fi)
 export COHYDRA_TAG := ${COHYDRA_TAG}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sudo pip3 install git+https://github.com/active-expressions/active-expressions-s
 The Python libraries / directory provided by ns-3 and all other packages has to be in your `PYTHONPATH`, though.
 To run an example testcase, go to the example folder and run:
 ```shell script
-pyton3 basic_example.py
+python3 basic_example.py
 ```
 
 Cohydra so far has only been tested with **Debian 10 Buster** and **Ubuntu 18.04 Bionic Beaver**.

--- a/cohydra/channel/wifi.py
+++ b/cohydra/channel/wifi.py
@@ -58,7 +58,7 @@ class WiFiChannel(Channel):
         #: Standard from 2013.
         WIFI_802_11ac = wifi.WIFI_PHY_STANDARD_80211ac
         #: "WiFi 6".
-        WIFI_802_11ax = wifi.WIFI_PHY_STANDARD_80211ax_2_4GHZ
+        WIFI_802_11ax = wifi.WIFI_PHY_STANDARD_80211ax
         ## Wireless Access in Vehicular Environments (WAVE).
         WIFI_802_11p = wifi.WIFI_PHY_STANDARD_80211_10MHZ
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,4 +3,4 @@ ARG COHYDRA_TAG=
 FROM osmhpi/cohydra:base${COHYDRA_TAG:+-$COHYDRA_TAG}
 
 COPY tools /usr/local/bin
-COPY cohydra /usr/local/lib/python3.7/dist-packages/cohydra
+COPY cohydra /usr/local/lib/python3.7/site-packages/cohydra

--- a/docker/cohydra-base/Dockerfile
+++ b/docker/cohydra-base/Dockerfile
@@ -1,5 +1,5 @@
 ARG SUMO_TAG=1.4.0
-ARG NS3_TAG=3.30
+ARG NS3_TAG=3.33
 
 FROM osmhpi/sumo:$SUMO_TAG AS sumo
 

--- a/docker/cohydra-base/Dockerfile
+++ b/docker/cohydra-base/Dockerfile
@@ -5,16 +5,6 @@ FROM osmhpi/sumo:$SUMO_TAG AS sumo
 
 FROM osmhpi/ns-3:$NS3_TAG
 
-RUN apt-get update && \
-	apt-get install -y --no-install-recommends \
-	git \
-	python3-pip \
-	python3-setuptools \
-	&& \
-	apt-get autoremove -y && \
-	apt-get clean -y && \
-	rm -rf /var/lib/apt/lists/*
-
 RUN pip3 install --no-cache-dir \
 	coloredlogs \
 	docker \

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -36,6 +36,6 @@ Local Installation Without Docker
 
 In the case you do not want to use the prebuilt docker, a normal ns-3 installation with *NetAnim* Python bindings will work, too.
 The Python libraries / directory provided by ns-3 has to be in your :code:`PYTHONPATH`, though.
-Cohydra so far has only been tested with **Debian 10 Buster**, **Ubuntu 18.04 Bionic Beaver** and **ns-3.30**.
+Cohydra so far has only been tested with **Debian 10 Buster**, **Ubuntu 18.04 Bionic Beaver** and **ns-3.33**.
 
 There is no installation via :code:`pip`.


### PR DESCRIPTION
This updates the dependency to the osmhpi/ns-3 docker image to the newer version 3.33.

Also, the cohydra-base docker image is now built from source during travis tests. Previously, the image was pulled from Docker hub, which might have been out of sync.

The basic example works but I have not yet conducted other tests.

---
[Documentation of `ns3-33`](https://osmhpi.github.io/cohydra/ns3-33)